### PR TITLE
chore: enable workflow dispatch

### DIFF
--- a/.github/workflows/jinja.yml
+++ b/.github/workflows/jinja.yml
@@ -6,6 +6,8 @@ name: Jinja
 on:
   push:
     branches: [ master ]
+  
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add workflow dispatch trigger to allow manual runs of the Jinja template rendering workflow.